### PR TITLE
Add Block based on SSTable in LevelDB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "lsm"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+thiserror = "1.0"
+leb128 = "0.2.1"

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,0 +1,113 @@
+#[path = "./lsm_error.rs"]
+mod lsm_error;
+
+use leb128;
+use crate::block::lsm_error::DataStoreError;
+/// Block Size defined for 128 KB.
+/// TODO: need to make it configurable 
+/// and experiment to set optimal size
+static BLOCK_SIZE: usize = 128 * 1024;
+/// Block has 'data_' which is contigous block
+/// of bytes consisting of contiguous entry.
+/// Format of an entry is concatenation of:
+///  key_size     : leb128 encoding of key size
+///  value_size   : leb128 encoding of value size
+///  key bytes    : char[key_size]
+///  value bytes  : char[value_size]
+struct Block {
+    /// Block data. Check the comment at struct Block
+    /// level for the detail about format. It would be
+    /// written to the Disk in the same format.
+    pub data_: Vec<u8>,
+    /// Length of data written to 'data_'.
+    pub current_pos_: usize,
+    /// Whether Block is closed or not.
+    pub finished_: bool
+}
+
+impl Block {
+    fn new() -> Block {
+        Block {
+            data_ : vec![0; BLOCK_SIZE],
+            current_pos_ : 0,
+            finished_ : false
+        }
+    }
+
+    fn add(&mut self, key: &[u8], value: &[u8])
+        -> Result<(), DataStoreError> {
+        debug_assert!(!self.finished_, "Block is already closed");
+        let key_len = key.len();
+        let value_len = value.len();
+        let mut writable = &mut self.data_[self.current_pos_..];
+        let key_len_bytes =
+            leb128::write::unsigned(&mut writable,
+                key_len.try_into().unwrap())
+            .unwrap();
+        self.current_pos_ += key_len_bytes;
+        writable = &mut self.data_[self.current_pos_..];
+        let value_len_bytes =
+            leb128::write::unsigned(&mut writable,
+                value_len.try_into().unwrap())
+            .unwrap();
+        self.current_pos_ += value_len_bytes;
+        self.data_[self.current_pos_..self.current_pos_ + key_len]
+            .copy_from_slice(key);
+        self.current_pos_ += key_len;
+        self.data_[self.current_pos_..self.current_pos_ + value_len]
+            .copy_from_slice(value);
+        self.current_pos_ += value_len;
+        return Ok(());
+    }
+
+    fn finish(&mut self) -> &[u8] {
+        self.finished_ = true;
+        return &self.data_[0..self.current_pos_];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::block::Block;
+
+    #[test]
+    fn insert_one_key_value() {
+        let mut b = Block::new();
+        assert!(b.add(b"key", b"value").is_ok());
+        b.finish();
+        assert_eq!(b.current_pos_, 10);
+        let expected_bytes =  [&[0x03 as u8, 0x05 as u8] as &[u8],
+            b"keyvalue"].concat();
+        let actual_bytes: &[u8] = &(b.data_)[0..b.current_pos_];
+        assert_eq!(expected_bytes, actual_bytes);
+    }
+
+    #[test]
+    fn insert_longer_keys_and_values() {
+        let mut b = Block::new();
+        let test_str_129 = ["c"; 129].join("");
+        // insert more than 129 characters i.e., > 128
+        // so that its length takes 2 bytes when encoded
+        // using leb128.
+        let value = test_str_129.as_bytes(); 
+        assert!(b.add(b"key", value).is_ok());
+        let mut expected_len = 3 /*key chars*/ + 129 /*value chars*/
+            + 1 /*keylen in leb128*/ + 2 /*valuelen in leb128*/;
+        assert_eq!(b.current_pos_, expected_len);
+        let mut expected_bytes = [&[0x03 as u8, 0x81 as u8, 0x01 as u8],
+            b"key", value].concat();
+        let mut actual_bytes = &(b.data_)[0..b.current_pos_];
+        assert_eq!(expected_bytes, actual_bytes);
+        // insert 129 characters key now.
+        let key = test_str_129.as_bytes();
+        assert!(b.add(key, value).is_ok());
+        expected_len += 129 /*key chars*/ + 129 /*value chars*/
+        + 2 + 2 /*both valuelen and keylen in leb128*/;
+        assert_eq!(b.current_pos_, expected_len);
+        expected_bytes = [&expected_bytes[0..],
+        &[0x81 as u8, 0x01 as u8, 0x81 as u8, 0x01 as u8],
+        key, value].concat();
+        actual_bytes = &(b.data_)[0..b.current_pos_];
+        assert_eq!(expected_bytes, actual_bytes);
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,33 @@
+struct SetCommand {
+    key: String,
+    value: String
+}
+
+struct RmCommand {
+    key: String,
+    value: String
+}
+
+trait Command {
+    fn getKey(&self) -> String;
+    fn getValue(&self) -> String;
+}
+
+impl Command for SetCommand {
+    fn getKey(&self) -> String {
+        return &self.key;        
+    }
+    fn getValue(&self) -> String {
+        return &self.value;
+    }
+}
+
+impl Command for RmCommand {
+    fn getKey(&self) -> String {
+        return &self.key;        
+    }
+    fn getValue(&self) -> String {
+        return &self.value;
+    }
+}
+

--- a/src/lsm_error.rs
+++ b/src/lsm_error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+/// Inspired by https://nick.groenen.me/posts/rust-error-handling/
+
+#[derive(Error, Debug)]
+pub enum DataStoreError {
+    #[error("invalid header (expected {expected:?}, found {found:?})")]
+    InvalidHeader {
+        expected: String,
+        found: String,
+    },
+    /// Represents all other cases of `std::io::Error`.
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+    #[error("unknown data store error")]
+    Unknown,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,5 @@
+mod block;
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -1,0 +1,78 @@
+/// Borrowed from https://snowbridge-rust-docs.snowfork.com/src/parity_wasm/elements/primitives.rs.html
+use crate::io;
+use super::{Error, Deserialize, Serialize};
+
+/// Unsigned variable-length integer, limited to 32 bits,
+/// represented by at most 5 bytes that may contain padding 0x80 bytes.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct VarUint32(u32);
+
+impl From<VarUint32> for usize {
+	fn from(var: VarUint32) -> usize {
+		var.0 as usize
+	}
+}
+
+impl From<VarUint32> for u32 {
+	fn from(var: VarUint32) -> u32 {
+		var.0
+	}
+}
+
+impl From<u32> for VarUint32 {
+	fn from(i: u32) -> VarUint32 {
+		VarUint32(i)
+	}
+}
+
+impl From<usize> for VarUint32 {
+	fn from(i: usize) -> VarUint32 {
+		assert!(i <= u32::max_value() as usize);
+		VarUint32(i as u32)
+	}
+}
+
+impl Deserialize for VarUint32 {
+	type Error = Error;
+
+	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+		let mut res = 0;
+		let mut shift = 0;
+		let mut u8buf = [0u8; 1];
+		loop {
+			if shift > 31 { return Err(Error::InvalidVarUint32); }
+
+			reader.read(&mut u8buf)?;
+			let b = u8buf[0] as u32;
+			res |= (b & 0x7f).checked_shl(shift).ok_or(Error::InvalidVarUint32)?;
+			shift += 7;
+			if (b >> 7) == 0 {
+				if shift >= 32 && (b as u8).leading_zeros() < 4 {
+					return Err(Error::InvalidVarInt32);
+				}
+				break;
+			}
+		}
+		Ok(VarUint32(res))
+	}
+}
+
+impl Serialize for VarUint32 {
+	type Error = Error;
+
+	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
+		let mut buf = [0u8; 1];
+		let mut v = self.0;
+		loop {
+			buf[0] = (v & 0b0111_1111) as u8;
+			v >>= 7;
+			if v > 0 {
+				buf[0] |= 0b1000_0000;
+			}
+			writer.write(&buf[..])?;
+			if v == 0 { break; }
+		}
+
+		Ok(())
+	}
+}


### PR DESCRIPTION
SSTable consists of multiple Blocks storing (key, value)
data. It is stored in contiguous fashion in this format:

<keylen in leb128> <valuelen in leb128> <key bytes> <value bytes>